### PR TITLE
add: refactoring, attributes to parse linear trees as well

### DIFF
--- a/slim_trees/lgbm_booster.py
+++ b/slim_trees/lgbm_booster.py
@@ -197,8 +197,9 @@ def _decompress_booster_handle(compressed_state: Tuple[str, List[dict], str]) ->
     assert type(trees) == list
     assert type(back_str) == str
 
-    handle = front_str
+    front_str += "tree_sizes=" + " ".join(["0" for t in trees]) + "\n"
 
+    handle = front_str
     for i, tree in enumerate(trees):
         _validate_tree_structure(tree)
         is_linear = int(tree["is_linear"])
@@ -239,11 +240,11 @@ def _decompress_booster_handle(compressed_state: Tuple[str, List[dict], str]) ->
                 f"\nleaf_coeff"
                 f"={' '.join(['' if np.isnan(f) else str(f) for f in tree['leaf_coeff']])}"
             )
-            tree_str += f"\nshrinkage={tree['shrinkage']}"
 
-            tree_str += "\n\n\n"
+        tree_str += f"\nshrinkage={int(tree['shrinkage'])}"
 
-            handle += tree_str
-            handle += back_str
+        tree_str += "\n\n\n"
+        handle += tree_str
 
+    handle += back_str
     return handle

--- a/slim_trees/lgbm_booster.py
+++ b/slim_trees/lgbm_booster.py
@@ -197,7 +197,7 @@ def _decompress_booster_handle(compressed_state: Tuple[str, List[dict], str]) ->
     assert type(trees) == list
     assert type(back_str) == str
 
-    front_str += "tree_sizes=" + " ".join(["0" for t in trees]) + "\n"
+    # front_str += "tree_sizes=" + " ".join(["0" for t in trees]) + "\n"
 
     handle = front_str
     for i, tree in enumerate(trees):

--- a/slim_trees/lgbm_booster.py
+++ b/slim_trees/lgbm_booster.py
@@ -227,18 +227,15 @@ def _decompress_booster_handle(compressed_state: Tuple[str, List[dict], str]) ->
         tree_str += f"\nis_linear={tree['is_linear']}"
         if is_linear:
             # TODO: attributes: leaf_features, leaf_coeff, leaf_const, num_features
-            tree_str += f"\nleaf_const={' '.join(str(x) for x in tree['leaf_const'])}"
-            tree_str += (
-                f"\nnum_features={' '.join(str(x) for x in tree['num_features'])}"
+            tree_str += "\nleaf_const=" + " ".join(str(x) for x in tree["leaf_const"])
+            tree_str += "\nnum_features=" + " ".join(
+                str(x) for x in tree["num_features"]
             )
-            tree_str += (
-                f"\nleaf_features"
-                f"={' '.join(['' if f == -1 else str(int(f)) for f in tree['leaf_features']])}"
+            tree_str += "\nleaf_features=" + " ".join(
+                "" if f == -1 else str(int(f)) for f in tree["leaf_features"]
             )
-
-            tree_str += (
-                f"\nleaf_coeff"
-                f"={' '.join(['' if np.isnan(f) else str(f) for f in tree['leaf_coeff']])}"
+            tree_str += "\nleaf_coeff=" + " ".join(
+                "" if np.isnan(f) else str(f) for f in tree["leaf_coeff"]
             )
 
         tree_str += f"\nshrinkage={int(tree['shrinkage'])}"

--- a/slim_trees/lgbm_booster.py
+++ b/slim_trees/lgbm_booster.py
@@ -197,8 +197,6 @@ def _decompress_booster_handle(compressed_state: Tuple[str, List[dict], str]) ->
     assert type(trees) == list
     assert type(back_str) == str
 
-    # front_str += "tree_sizes=" + " ".join(["0" for t in trees]) + "\n"
-
     handle = front_str
     for i, tree in enumerate(trees):
         _validate_tree_structure(tree)
@@ -226,7 +224,6 @@ def _decompress_booster_handle(compressed_state: Tuple[str, List[dict], str]) ->
         tree_str += "\ninternal_count=" + ("0 " * num_nodes)[:-1]
         tree_str += f"\nis_linear={tree['is_linear']}"
         if is_linear:
-            # TODO: attributes: leaf_features, leaf_coeff, leaf_const, num_features
             tree_str += "\nleaf_const=" + " ".join(str(x) for x in tree["leaf_const"])
             tree_str += "\nnum_features=" + " ".join(
                 str(x) for x in tree["num_features"]

--- a/tests/test_lgbm_compression.py
+++ b/tests/test_lgbm_compression.py
@@ -37,6 +37,7 @@ def test_model_string_equality(diabetes_toy_df, lgbm_regressor):
     Nevertheless, for required features, some string rows should be equal.
     This helps in debugging that.
     """
+    # lgbm_regressor = lgbm_regressor_linear
     lgbm_regressor.fit(*diabetes_toy_df)
 
     # get regular model string

--- a/tests/test_lgbm_compression.py
+++ b/tests/test_lgbm_compression.py
@@ -11,11 +11,7 @@ from util import (
 )
 
 from slim_trees import dump_lgbm_compressed
-from slim_trees.lgbm_booster import (
-    _booster_pickle,
-    _compress_booster_state,
-    _decompress_booster_state,
-)
+from slim_trees.lgbm_booster import _booster_pickle
 from slim_trees.pickling import dump_compressed, load_compressed
 
 
@@ -27,27 +23,6 @@ def lgbm_regressor(rng):
 @pytest.fixture
 def lgbm_regressor_linear(rng):
     return LGBMRegressor(random_state=rng, linear_trees=True)
-
-
-@pytest.mark.xfail(reason="reconstructed model string is not expected to be equal")
-def test_model_string_equality(diabetes_toy_df, lgbm_regressor):
-    """
-    This test should fail because the model string
-    will not be equivalent since we're omitting values.
-    Nevertheless, for required features, some string rows should be equal.
-    This helps in debugging that.
-    """
-    # lgbm_regressor = lgbm_regressor_linear
-    lgbm_regressor.fit(*diabetes_toy_df)
-
-    # get regular model string
-    model_str = lgbm_regressor.booster_.__reduce__()[2]["handle"]
-
-    # get our reconstructed model string
-    compressed_state = _compress_booster_state(lgbm_regressor.booster_.__reduce__()[2])
-    reconstructed_model_str = _decompress_booster_state(compressed_state)["handle"]
-
-    assert model_str == reconstructed_model_str
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lgbm_compression.py
+++ b/tests/test_lgbm_compression.py
@@ -11,7 +11,11 @@ from util import (
 )
 
 from slim_trees import dump_lgbm_compressed
-from slim_trees.lgbm_booster import _booster_pickle
+from slim_trees.lgbm_booster import (
+    _booster_pickle,
+    _compress_booster_state,
+    _decompress_booster_state,
+)
 from slim_trees.pickling import dump_compressed, load_compressed
 
 
@@ -20,7 +24,35 @@ def lgbm_regressor(rng):
     return LGBMRegressor(random_state=rng)
 
 
-def test_compresed_predictions(diabetes_toy_df, lgbm_regressor, tmp_path):
+@pytest.fixture
+def lgbm_regressor_linear(rng):
+    return LGBMRegressor(random_state=rng, linear_trees=True)
+
+
+@pytest.mark.xfail(reason="reconstructed model string is not expected to be equal")
+def test_model_string_equality(diabetes_toy_df, lgbm_regressor):
+    """
+    This test should fail because the model string
+    will not be equivalent since we're omitting values.
+    Nevertheless, for required features, some string rows should be equal.
+    This helps in debugging that.
+    """
+    lgbm_regressor.fit(*diabetes_toy_df)
+
+    # get regular model string
+    model_str = lgbm_regressor.booster_.__reduce__()[2]["handle"]
+
+    # get our reconstructed model string
+    compressed_state = _compress_booster_state(lgbm_regressor.booster_.__reduce__()[2])
+    reconstructed_model_str = _decompress_booster_state(compressed_state)["handle"]
+
+    assert model_str == reconstructed_model_str
+
+
+@pytest.mark.parametrize(
+    "lgbm_regressor", [lgbm_regressor, lgbm_regressor_linear], indirect=True
+)
+def test_compressed_predictions(diabetes_toy_df, lgbm_regressor, tmp_path):
     X, y = diabetes_toy_df
     lgbm_regressor.fit(X, y)
 


### PR DESCRIPTION
This is a new PR that incorporates _some_ of the changes in #15 
The other PR can stay open (as a draft maybe) as a reference though I'm not optimistic what its chances of success are, since lzma seems to be doing most of the optimization already.

---
changes here include

- [x] some light refactoring
- [x] start on supporting linear trees in lgbm
- [ ] (maybe) some refactoring on the benchmarks